### PR TITLE
Fix .when() behaviour

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ spider.get("/")
 ```javascript
 const spider = crawlerr("http://blog.npmjs.org/");
 
-spider.when("/post/[digit:id]/[all:slug]").then(({ req, res, uri }) => {
+spider.when("/post/[digit:id]/[all:slug]", ({ req, res, uri }) => {
   const post = req.param("id");
   const slug = req.param("slug").split("?")[0];
 
@@ -122,8 +122,7 @@ Searches the entire website for urls which match the specified `pattern`. `patte
 
 ```javascript
 spider
-  .when("/users/[digit:userId]/repos/[digit:repoId]")
-  .then(({ res, req, uri }) => …);
+  .when("/users/[digit:userId]/repos/[digit:repoId]", ({ res, req, uri }) => …);
 ```
 
 <br />

--- a/dist/routing/router.js
+++ b/dist/routing/router.js
@@ -14,10 +14,6 @@ var _retryRequest = require("retry-request");
 
 var _retryRequest2 = _interopRequireDefault(_retryRequest);
 
-var _mergeDescriptors = require("merge-descriptors");
-
-var _mergeDescriptors2 = _interopRequireDefault(_mergeDescriptors);
-
 var _getLink = require("get-link");
 
 var _getLink2 = _interopRequireDefault(_getLink);
@@ -182,7 +178,8 @@ exports.default = {
       if (uri === index || parameters) {
         // Merge request parameters with wildcard output:
         // NOTE: pheraps we should override params on each callback?
-        (0, _mergeDescriptors2.default)(req.params || {}, parameters || {});
+        req.params = _extends({}, req.params, parameters);
+        // mixin(req.params || {}, parameters || {});
 
         callback({ req: req, res: res, uri: uri });
       }

--- a/dist/routing/router.js
+++ b/dist/routing/router.js
@@ -51,17 +51,11 @@ exports.default = {
    *
    * @param   {string}    uri
    * @param   {Function}  callback
-   * @return  {Promise}
+   * @return  {void}
    * @access  public
    */
   when: function when(uri, callback) {
-    var _this = this;
-
-    uri = this.normalizeUri(uri);
-
-    return new Promise(function (resolve) {
-      _this.callbacks[uri] = callback;
-    });
+    this.callbacks[this.normalizeUri(uri)] = callback;
   },
 
 
@@ -74,7 +68,7 @@ exports.default = {
    * @access  public
    */
   get: function get(uri) {
-    var _this2 = this;
+    var _this = this;
 
     var opts = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : defaultOptions;
 
@@ -95,8 +89,8 @@ exports.default = {
         req.res = res;
 
         // Alter the prototypes:
-        (0, _setprototypeof2.default)(req, _this2.req);
-        (0, _setprototypeof2.default)(res, _this2.res);
+        (0, _setprototypeof2.default)(req, _this.req);
+        (0, _setprototypeof2.default)(res, _this.res);
 
         resolve({ req: req, res: res, uri: uri });
       });

--- a/dist/routing/router.js
+++ b/dist/routing/router.js
@@ -50,16 +50,17 @@ exports.default = {
    * Add a handler for a specific uri. Accepts wildcards.
    *
    * @param   {string}    uri
+   * @param   {Function}  callback
    * @return  {Promise}
    * @access  public
    */
-  when: function when(uri) {
+  when: function when(uri, callback) {
     var _this = this;
 
     uri = this.normalizeUri(uri);
 
     return new Promise(function (resolve) {
-      _this.callbacks[uri] = resolve;
+      _this.callbacks[uri] = callback;
     });
   },
 

--- a/examples/list_posts.js
+++ b/examples/list_posts.js
@@ -1,7 +1,7 @@
 const crawler = require("../dist");
 const spider = crawler("http://blog.npmjs.org/");
 
-spider.when("/post/[digit:id]/[all:slug]").then(({ req, res, uri }) => {
+spider.when("/post/[digit:id]/[all:slug]", ({ req, res, uri }) => {
   const id = req.param("id");
   const slug = req.param("slug").split("?")[0];
 

--- a/src/routing/router.js
+++ b/src/routing/router.js
@@ -26,15 +26,11 @@ export default {
    *
    * @param   {string}    uri
    * @param   {Function}  callback
-   * @return  {Promise}
+   * @return  {void}
    * @access  public
    */
-  when(uri: string, callback: Function): Promise<*> {
-    uri = this.normalizeUri(uri);
-
-    return new Promise(resolve => {
-      this.callbacks[uri] = callback;
-    });
+  when(uri: string, callback: Function): void {
+    this.callbacks[this.normalizeUri(uri)] = callback;
   },
 
   /**

--- a/src/routing/router.js
+++ b/src/routing/router.js
@@ -25,14 +25,15 @@ export default {
    * Add a handler for a specific uri. Accepts wildcards.
    *
    * @param   {string}    uri
+   * @param   {Function}  Callback function
    * @return  {Promise}
    * @access  public
    */
-  when(uri: string): Promise<*> {
+  when(uri: string, callback: Function): Promise<*> {
     uri = this.normalizeUri(uri);
 
     return new Promise(resolve => {
-      this.callbacks[uri] = resolve;
+      this.callbacks[uri] = callback;
     });
   },
 

--- a/src/routing/router.js
+++ b/src/routing/router.js
@@ -25,7 +25,7 @@ export default {
    * Add a handler for a specific uri. Accepts wildcards.
    *
    * @param   {string}    uri
-   * @param   {Function}  Callback function
+   * @param   {Function}  callback
    * @return  {Promise}
    * @access  public
    */

--- a/src/routing/router.js
+++ b/src/routing/router.js
@@ -2,7 +2,6 @@
 
 import url from "url";
 import retryRequest from "retry-request";
-import mixin from "merge-descriptors";
 import getLink from "get-link";
 import wildcard from "wildcard-named";
 import setPrototypeOf from "setprototypeof";
@@ -128,7 +127,8 @@ export default {
       if (uri === index || parameters) {
         // Merge request parameters with wildcard output:
         // NOTE: pheraps we should override params on each callback?
-        mixin(req.params || {}, parameters || {});
+        req.params = { ...req.params, ...parameters };
+        // mixin(req.params || {}, parameters || {});
 
         callback({ req, res, uri });
       }

--- a/test/index.js
+++ b/test/index.js
@@ -37,17 +37,17 @@ describe("crawlerr", function () {
     });
 
     describe(".when(pattern)", function () {
-      it("should handle promises", function () {
-        let spider = crawlerr("https://google.com/");
-
-        expect(spider.when("/")).to.have.property("then");
-        expect(spider.when("/")).to.have.property("catch");
-      });
+      // it("should handle promises", function () {
+      //   let spider = crawlerr("https://google.com/");
+      //
+      //   expect(spider.when("/")).to.have.property("then");
+      //   expect(spider.when("/")).to.have.property("catch");
+      // });
 
       it("should handle a valid request", function (done) {
         let spider = crawlerr("https://google.com/");
 
-        spider.when("/").then(({ req, res, uri }) => {
+        spider.when("/", ({ req, res, uri }) => {
           spider.stop();
 
           expect(req).to.be.an("object");


### PR DESCRIPTION
I dug a bit in the code and found that using a callback function makes the crawler work as expected using the `when` method.

The current behaviour as in issue #34 is because the promise only resolves once and the code inside `then()` is therefore only run once. Using a callback function and completely dropping the top most `then` method makes the crawler crawl again.

Please tell me what you think?