### PR TITLE
Specify nodejs version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ dist: trusty
 language: node_js
 
 node_js:
-  - node
+  - "10.0.0"
 
 cache:
   directories:


### PR DESCRIPTION
Crawlerr is only compatible with nodejs 10.0 and below.